### PR TITLE
feat: allow Dependabot's "deps-dev" scope

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,7 +8,7 @@ module.exports = {
             maxLength: 100,
             dependencyCommit: {
               type: /^(chore|fix)/,
-              scope: /^(peer-)?deps$/,
+              scope: /^(peer-)?deps(-dev)?$/,
               maxLength: 200,
             },
           };

--- a/src/rules/header-max-length.ts
+++ b/src/rules/header-max-length.ts
@@ -5,7 +5,7 @@ function headerMaxLength(parsed: Commit): RuleOutcome {
     maxLength: 100,
     dependencyCommit: {
       type: /^(chore|fix)$/,
-      scope: /^(peer-)?deps$/,
+      scope: /^(peer-)?deps(-dev)?$/,
       maxLength: 200,
     },
   };

--- a/src/rules/header-max-length.unit.test.ts
+++ b/src/rules/header-max-length.unit.test.ts
@@ -59,7 +59,14 @@ describe('headerMaxLength', () => {
     expect(result).toEqual(expectedResult);
   });
 
-  it.each(['chore(deps)', 'fix(deps)', 'chore(peer-deps)', 'fix(peer-deps)'])(
+  it.each([
+    'chore(deps)',
+    'fix(deps)',
+    'chore(peer-deps)',
+    'fix(peer-deps)',
+    'chore(deps-dev)',
+    'fix(deps-dev)',
+  ])(
     "succeeds with a short '%s' dependency message",
     async (prefix: string) => {
       const message = await parse(
@@ -74,26 +81,30 @@ describe('headerMaxLength', () => {
     },
   );
 
-  it.each(['chore(deps)', 'fix(deps)', 'chore(peer-deps)', 'fix(peer-deps)'])(
-    "fails with a long '%s' dependency message",
-    async (prefix: string) => {
-      const message = await parse(
-        `${prefix}: ${messageConfig.dependency}`.padEnd(
-          messageConfig.maxDependencyLength + 1,
-          messageConfig.padding,
-        ),
-      );
-      const expectedResult: RuleOutcome = [
-        false,
-        [
-          'header for dependency commits must not be longer than',
-          `${messageConfig.maxDependencyLength} characters, current length is`,
-          message.raw.length,
-        ].join(' '),
-      ];
-      const result = headerMaxLength(message);
+  it.each([
+    'chore(deps)',
+    'fix(deps)',
+    'chore(peer-deps)',
+    'fix(peer-deps)',
+    'chore(deps-dev)',
+    'fix(deps-dev)',
+  ])("fails with a long '%s' dependency message", async (prefix: string) => {
+    const message = await parse(
+      `${prefix}: ${messageConfig.dependency}`.padEnd(
+        messageConfig.maxDependencyLength + 1,
+        messageConfig.padding,
+      ),
+    );
+    const expectedResult: RuleOutcome = [
+      false,
+      [
+        'header for dependency commits must not be longer than',
+        `${messageConfig.maxDependencyLength} characters, current length is`,
+        message.raw.length,
+      ].join(' '),
+    ];
+    const result = headerMaxLength(message);
 
-      expect(result).toEqual(expectedResult);
-    },
-  );
+    expect(result).toEqual(expectedResult);
+  });
 });


### PR DESCRIPTION
Hey! Thanks for putting this together. We're also needing a configuration like this to address Dependabot's commits breaking commitlint's very strict line length rules. I'd like to propose a change which extends this config to cover Dependabot functionality, as they use the "deps-dev" scope when a dependency is updated in the `devDependencies` field.

An example of the "deps-dev" scope in a PR here: https://github.com/streetmix/streetmix/pull/2181

Thanks!